### PR TITLE
packagename -> spotdot

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,8 +76,10 @@ copyright = '{0}, {1}'.format(
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-import_module(setup_cfg['name'])
-package = sys.modules[setup_cfg['name']]
+# Note: For dot, the package name is different from the project name!
+package_name = 'dot'
+import_module(package_name)
+package = sys.modules[package_name]
 
 # The short X.Y version.
 version = package.__version__.split('-', 1)[0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = dot
+name = spotdot
 author = Brett M. Morris
 author_email = morrisbrettm@gmail.com
 license = BSD 3-Clause


### PR DESCRIPTION
`dot` turns out to be a protected name on PyPI so we have to use a different name for `pip install`. Migrating the package name on the registry to `spotdot`, but keeping the package called `dot`.