### PR TITLE
API revisions

### DIFF
--- a/docs/dot/forwardmodel.rst
+++ b/docs/dot/forwardmodel.rst
@@ -1,0 +1,203 @@
+.. _forward-model:
+
+*************
+Forward Model
+*************
+
+Single Spot
+-----------
+
+Perhaps the best way to learn how ``dot`` works is to experiment with it, which
+we will do in this tutorial. Let's suppose first we have a star with a single
+spot, defined its latitude, longitude, and radius. We'll place the star on the
+prime meridian (zero point in longitude) and the equator. We'll give the star
+a rotation period of 0.5 days, and the spot will have contrast 0.3. To do this,
+we'll first need to generate an instance of the `~dot.Model` object:
+
+.. code-block:: python
+
+    import pymc3 as pm
+    import numpy as np
+    from lightkurve import LightCurve
+
+    from dot import Model
+
+    times = np.linspace(-1, 1, 1000)
+    fluxes = np.zeros_like(times)
+    errors = np.ones_like(times)
+
+    rotation_period = 0.5  # days
+    stellar_inclination = 90  # deg
+
+    m = Model(
+        light_curve=LightCurve(times, fluxes, errors),
+        rotation_period=rotation_period,
+        n_spots=1,
+        contrast=0.3
+    )
+
+Now that our `~dot.Model` is specified and the time points are defined in the
+`~lightkurve.lightcurve.LightCurve` object, we can specify the spot properties:
+
+.. code-block:: python
+
+    # Create a starting point for the dot model
+    start_params = {
+        "dot_R_spot": np.array([0.1]),
+        "dot_lat": np.array([np.pi/2]),
+        "dot_lon": np.array([0]),
+        "dot_comp_inc": np.radians(90 - stellar_inclination),
+        "dot_ln_shear": -3,
+        "dot_P_eq": rotation_period,
+        "dot_f0": 1
+    }
+
+    # Need to call this to validate ``start``
+    pm.util.update_start_vals(start, m.pymc_model.test_point, m.pymc_model)
+
+We specify spot properties with a dictionary which contains the spot radii,
+latitudes, longitudes, the complementary angle to the stellar inclination, the
+natural log of the shear rate, the equatorial rotation period and the
+baseline flux of the star. We then call `~pymc3.util.update_start_vals` on the
+dictionary with our `~dot.Model` object, which translates the user-facing,
+human-friendly coordinates into the optimizer-friendly transformed coordinates.
+
+We can now call our model on the start dictionary, and plot it like so:
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+
+    forward_model_start = m(start_params)
+
+    plt.plot(m.lc.time[m.mask], m.lc.flux[m.mask], m.lc.flux_err[m.mask],
+             color='k', fmt='.', ecolor='silver')
+    plt.plot(m.lc.time[m.mask][::m.skip_n_points], forward_model_start,
+             color='DodgerBlue')
+    plt.show()
+
+.. plot::
+
+    import pymc3 as pm
+    import numpy as np
+    from lightkurve import LightCurve
+
+    from dot import Model
+
+    times = np.linspace(-1, 1, 1000)
+    fluxes = np.zeros_like(times)
+    errors = np.ones_like(times)
+
+    rotation_period = 0.5  # days
+    stellar_inclination = 90  # deg
+
+    m = Model(
+        light_curve=LightCurve(times, fluxes, errors),
+        rotation_period=rotation_period,
+        n_spots=1,
+        contrast=0.3
+    )
+
+    # Create a starting point for the dot model
+    start_params = {
+        "dot_R_spot": np.array([[0.1]]),
+        "dot_lat": np.array([[np.pi/2]]),
+        "dot_lon": np.array([[0]]),
+        "dot_comp_inc": np.radians(90 - stellar_inclination),
+        "dot_ln_shear": -3,
+        "dot_P_eq": rotation_period,
+        "dot_f0": 1
+    }
+
+    # Need to call this to validate ``start``
+    pm.util.update_start_vals(start_params, m.pymc_model.test_point, m.pymc_model)
+
+    import matplotlib.pyplot as plt
+
+    forward_model_start = m(start_params)
+
+    plt.plot(m.lc.time[m.mask][::m.skip_n_points], forward_model_start,
+             color='DodgerBlue')
+    plt.gca().set(xlabel='Time [d]', ylabel='Flux')
+    plt.show()
+
+In the above plot, we see the forward model for the spot modulation of a single
+spot on a rotating star.
+
+Differentially rotating spots
+-----------------------------
+
+The syntax is similar for multiple spots, we just add extra elements to the
+numpy arrays which determine the spot parameters, like so:
+
+.. code-block:: python
+
+    m = Model(
+        light_curve=LightCurve(times, fluxes, errors),
+        rotation_period=rotation_period,
+        n_spots=2,
+        contrast=0.3
+    )
+
+    # Create a starting point for the dot model
+    two_spot_params = {
+        "dot_R_spot": np.array([[0.1, 0.05]]),
+        "dot_lat": np.array([[np.pi/2, np.pi/4]]),
+        "dot_lon": np.array([[0, np.pi]]),
+        "dot_comp_inc": np.radians(90 - stellar_inclination),
+        "dot_ln_shear": np.log(0.2),
+        "dot_P_eq": rotation_period,
+        "dot_f0": 1
+    }
+
+Note this time that we've set the shear rate to 0.2, which is the solar shear
+rate. This time when we plot the result we'll see a more complicated model:
+
+.. plot::
+
+    import pymc3 as pm
+    import numpy as np
+    from lightkurve import LightCurve
+
+    from dot import Model
+
+    times = np.linspace(-1, 1, 1000)
+    fluxes = np.zeros_like(times)
+    errors = np.ones_like(times)
+
+    rotation_period = 0.5  # days
+    stellar_inclination = 90  # deg
+
+    m = Model(
+        light_curve=LightCurve(times, fluxes, errors),
+        rotation_period=rotation_period,
+        n_spots=2,
+        contrast=0.3
+    )
+
+    # Create a starting point for the dot model
+    two_spot_params = {
+        "dot_R_spot": np.array([[0.1, 0.05]]),
+        "dot_lat": np.array([[np.pi/2, np.pi/4]]),
+        "dot_lon": np.array([[0, np.pi]]),
+        "dot_comp_inc": np.radians(90 - stellar_inclination),
+        "dot_ln_shear": np.log(0.2),
+        "dot_P_eq": rotation_period,
+        "dot_f0": 1
+    }
+
+    # Need to call this to validate ``two_spot_params``
+    pm.util.update_start_vals(two_spot_params, m.pymc_model.test_point, m.pymc_model)
+
+    import matplotlib.pyplot as plt
+
+    forward_model_two = m(two_spot_params)
+
+    plt.plot(m.lc.time[m.mask][::m.skip_n_points], forward_model_two,
+             color='DodgerBlue')
+    plt.gca().set(xlabel='Time [d]', ylabel='Flux')
+    plt.show()
+
+Now you can see the effect of differential rotation on the light curve -- the
+smaller, higher latitude spot is rotating around the stellar surface with a
+different rate than the large, equatorial spot.

--- a/docs/dot/gettingstarted.rst
+++ b/docs/dot/gettingstarted.rst
@@ -162,11 +162,6 @@ very important. This uses `Daniel Foreman-Mackey's dense mass matrix setting
 <https://dfm.io/posts/pymc3-mass-matrix/>`_ which is critical for getting fast
 results from highly degenerate model parameterizations (like this one).
 
-The ``init`` keyword argument is set to ``'jitter+adapt_full'``, and this is
-very important. This uses Daniel Foreman-Mackey's dense mass matrix setting
-which is critical for getting fast results from highly degenerate model
-parameterizations (like this one).
-
 Finally, let's plot our results:
 
 .. code-block:: python

--- a/docs/dot/gettingstarted.rst
+++ b/docs/dot/gettingstarted.rst
@@ -84,7 +84,9 @@ In real observations, you should make ``skip_n_points`` closer to unity.
 
 The first thing we should do is check if our model can approximate the data.
 Here's a quick sanity check that our model is defined on the correct bounds,
-our errorbar scaling is appropriate, and the number of spots is a good guess:
+our errorbar scaling is appropriate, and the number of spots is a good guess,
+which we get from running `~pymc3.tuning.find_MAP` which finds the maximum
+a posteriori solution:
 
 .. code-block:: python
 
@@ -150,14 +152,15 @@ We'll sample the posterior distributions using the
         trace_nuts = pm.sample(start=map_soln, draws=1000, cores=2,
                                init='jitter+adapt_full')
 
-The values for ``draws`` and ``tune`` used above are chosen to produce quick
-plots, not to give converged publication-ready results. Always make these
-parameters as large as you can tolerate!
+where we use `~pymc3.sampling.sample` to draw samples from the posterior
+distribution. The value for ``draws`` used above are chosen to produce quick
+plots, not to give converged publication-ready results. Always make the
+``draws`` and ``tune`` parameters as large as you can tolerate!
 
 The ``init`` keyword argument is set to ``'jitter+adapt_full'``, and this is
-very important. This uses Daniel Foreman-Mackey's dense mass matrix setting
-which is critical for getting fast results from highly degenerate model
-parameterizations (like this one).
+very important. This uses `Daniel Foreman-Mackey's dense mass matrix setting
+<https://dfm.io/posts/pymc3-mass-matrix/>`_ which is critical for getting fast
+results from highly degenerate model parameterizations (like this one).
 
 Finally, let's plot our results:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ is `available on GitHub <https://github.com/bmorris3/dot>`_.
 
   dot/install.rst
   dot/gettingstarted.rst
+  dot/forwardmodel.rst
   dot/plots.rst
   dot/index.rst
   dot/dev.rst

--- a/dot/model.py
+++ b/dot/model.py
@@ -2,7 +2,6 @@ import logging
 
 import numpy as np
 import pymc3 as pm
-from pymc3.smc import sample_smc
 
 __all__ = ['Model']
 
@@ -243,91 +242,6 @@ class Model(object):
         """
         if self.pymc_model is None:
             raise ValueError('Must first call `Model._initialize_model` first.')
-
-    def sample_smc(self, draws, random_seed=42, **kwargs):
-        """
-        Sample the posterior distribution of the model given the data using
-        Sequential Monte Carlo.
-
-        Parameters
-        ----------
-        draws : int
-            Draws for the SMC sampler
-        random_seed : int
-            Random seed
-        parallel : bool
-            If True, run in parallel
-        cores : int
-            If `parallel`, run on this many cores
-
-        Returns
-        -------
-        trace : `~pymc3.backends.base.MultiTrace`
-        """
-        self._check_model()
-        with DisableLogger(self.verbose):
-            with self.pymc_model:
-                trace = sample_smc(draws, random_seed=random_seed, **kwargs)
-        return trace
-
-    def sample_nuts(self, trace_smc, draws, cores=96,
-                    target_accept=0.99, **kwargs):
-        """
-        Sample the posterior distribution of the model given the data using
-        the No U-Turn Sampler.
-
-        Parameters
-        ----------
-        trace_smc : `~pymc3.backends.base.MultiTrace`
-            Results from the SMC sampler
-        draws : int
-            Draws for the SMC sampler
-        cores : int
-            Run on this many cores
-        target_accept : float
-            Increase this number up to unity to decrease divergences
-
-        Returns
-        -------
-        trace : `~pymc3.backends.base.MultiTrace`
-            Results of the NUTS sampler
-        """
-        self._check_model()
-        with DisableLogger(self.verbose):
-            with self.pymc_model:
-                trace = pm.sample(draws,
-                                  start=trace_smc.point(-1), cores=cores,
-                                  target_accept=target_accept, **kwargs)
-                summary = pm.summary(trace)
-
-        return trace, summary
-
-    def optimize(self, start=None, plot=False, **kwargs):
-        """
-        Optimize the free parameters in `Model` using
-        `~scipy.optimize.minimize` via `~exoplanet.optimize`
-
-        Thanks x1000 to Daniel Foreman-Mackey for making this possible.
-        """
-        from exoplanet import optimize
-
-        with self.pymc_model:
-            map_soln = optimize(start=start, **kwargs)
-
-        if plot:
-            best_fit = self(map_soln)
-
-            import matplotlib.pyplot as plt
-            ax = plt.gca()
-            ax.errorbar(self.lc.time[self.mask][::self.skip_n_points],
-                        self.lc.flux[self.mask][::self.skip_n_points],
-                        self.lc.flux_err[self.mask][::self.skip_n_points],
-                        fmt='.', color='k', ecolor='silver', label='obs')
-            ax.plot(self.lc.time[self.mask][::self.skip_n_points],
-                    best_fit, label='dot')
-            ax.set(xlabel='Time', ylabel='Flux')
-            ax.legend(loc='lower left')
-        return map_soln
 
     def __call__(self, point=None, **kwargs):
         """

--- a/dot/model.py
+++ b/dot/model.py
@@ -33,10 +33,9 @@ class MeanModel(pm.gp.mean.Mean):
         self.ln_shear = pm.Uniform("ln_shear", lower=-5, upper=np.log(0.8),
                                    testval=np.log(0.1))
 
-        eps = 1e-5  # Small but non-zero number
         self.comp_inclination = pm.Uniform("comp_inc",
-                                           lower=np.radians(eps),
-                                           upper=np.radians(90-eps),
+                                           lower=0,
+                                           upper=np.pi/2,
                                            testval=np.radians(1))
 
         if partition_lon:
@@ -60,6 +59,7 @@ class MeanModel(pm.gp.mean.Mean):
                               shape=(1, n_spots),
                               testval=np.pi/2)
 
+        eps = 1e-5  # Small but non-zero number
         BoundedHalfNormal = pm.Bound(pm.HalfNormal, lower=eps, upper=0.8)
         self.rspot = BoundedHalfNormal("R_spot",
                                        sigma=0.2,

--- a/dot/model.py
+++ b/dot/model.py
@@ -2,7 +2,6 @@ import logging
 
 import numpy as np
 import pymc3 as pm
-from pymc3.smc import sample_smc
 
 __all__ = ['Model']
 
@@ -247,91 +246,6 @@ class Model(object):
         """
         if self.pymc_model is None:
             raise ValueError('Must first call `Model._initialize_model` first.')
-
-    def sample_smc(self, draws, random_seed=42, **kwargs):
-        """
-        Sample the posterior distribution of the model given the data using
-        Sequential Monte Carlo.
-
-        Parameters
-        ----------
-        draws : int
-            Draws for the SMC sampler
-        random_seed : int
-            Random seed
-        parallel : bool
-            If True, run in parallel
-        cores : int
-            If `parallel`, run on this many cores
-
-        Returns
-        -------
-        trace : `~pymc3.backends.base.MultiTrace`
-        """
-        self._check_model()
-        with DisableLogger(self.verbose):
-            with self.pymc_model:
-                trace = sample_smc(draws, random_seed=random_seed, **kwargs)
-        return trace
-
-    def sample_nuts(self, trace_smc, draws, cores=96,
-                    target_accept=0.99, **kwargs):
-        """
-        Sample the posterior distribution of the model given the data using
-        the No U-Turn Sampler.
-
-        Parameters
-        ----------
-        trace_smc : `~pymc3.backends.base.MultiTrace`
-            Results from the SMC sampler
-        draws : int
-            Draws for the SMC sampler
-        cores : int
-            Run on this many cores
-        target_accept : float
-            Increase this number up to unity to decrease divergences
-
-        Returns
-        -------
-        trace : `~pymc3.backends.base.MultiTrace`
-            Results of the NUTS sampler
-        """
-        self._check_model()
-        with DisableLogger(self.verbose):
-            with self.pymc_model:
-                trace = pm.sample(draws,
-                                  start=trace_smc.point(-1), cores=cores,
-                                  target_accept=target_accept, **kwargs)
-                summary = pm.summary(trace)
-
-        return trace, summary
-
-    def optimize(self, start=None, plot=False, **kwargs):
-        """
-        Optimize the free parameters in `Model` using
-        `~scipy.optimize.minimize` via `~exoplanet.optimize`
-
-        Thanks x1000 to Daniel Foreman-Mackey for making this possible.
-        """
-        from exoplanet import optimize
-
-        with self.pymc_model:
-            map_soln = optimize(start=start, **kwargs)
-
-        if plot:
-            best_fit = self(map_soln)
-
-            import matplotlib.pyplot as plt
-            ax = plt.gca()
-            ax.errorbar(self.lc.time[self.mask][::self.skip_n_points],
-                        self.lc.flux[self.mask][::self.skip_n_points],
-                        self.lc.flux_err[self.mask][::self.skip_n_points],
-                        fmt='.', color='k', ecolor='silver', label='obs')
-            ax.plot(self.lc.time[self.mask][::self.skip_n_points],
-                    best_fit, label='dot')
-            ax.set(xlabel='Time', ylabel='Flux')
-            ax.legend(loc='lower left')
-        return map_soln
 
     def __call__(self, point=None, **kwargs):
         """

--- a/dot/model.py
+++ b/dot/model.py
@@ -20,7 +20,7 @@ class MeanModel(pm.gp.mean.Mean):
         self.contrast = contrast
 
         self.f0 = pm.TruncatedNormal("f0", mu=0, sigma=1,
-                                     testval=np.percentile(light_curve.flux, 80),
+                                     testval=0,
                                      lower=-1, upper=2)
 
         self.eq_period = pm.TruncatedNormal("P_eq",
@@ -120,7 +120,7 @@ class Model(object):
     def __init__(self, light_curve, rotation_period, n_spots, scale_errors=1,
                  skip_n_points=1, latitude_cutoff=10, rho_factor=250,
                  verbose=False, min_time=None, max_time=None, contrast=0.7,
-                 partition_lon=False):
+                 partition_lon=True):
         """
         Construct a new instance of `~dot.Model`.
 


### PR DESCRIPTION
* switching to pymc3-style sampling in docs, *deleting* the `sample_nuts`, `sample_smc`, `optimize` methods.
  * new plan is to use `pm.sample`, `pm.smc.sample_smc` and `pm.find_MAP` methods
* adding a forward model tutorial
* switching to `partition_lons=True` by default
* letting stellar inclination vary all the way from (0, pi/2)